### PR TITLE
Fix link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 See AEP 0 on how to submit new AEPs.
 -->
 
- - [ ] Used [AEP template](../blob/master/0_aep_guidelines/aep_guidelines.md) from AEP 0
+ - [ ] Used [AEP template](../blob/master/000_aep_guidelines/aep_guidelines.md) from AEP 0
  - [ ] Status is `submitted`
  - [ ] Added type & status labels to PR
  - [ ] Added AEP to `README.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 See AEP 0 on how to submit new AEPs.
 -->
 
- - [ ] Used [AEP template](../blob/master/000_aep_guidelines/aep_guidelines.md) from AEP 0
+ - [ ] Used [AEP template](../blob/master/000_aep_guidelines/readme.md) from AEP 0
  - [ ] Status is `submitted`
  - [ ] Added type & status labels to PR
  - [ ] Added AEP to `README.md`


### PR DESCRIPTION
This should fix the link to the AEP guidelines in the PR template description.